### PR TITLE
REFACTOR: LoadingHandler

### DIFF
--- a/MicroGame-2022-10/Assets/00_Meta/Scenes/L00.unity
+++ b/MicroGame-2022-10/Assets/00_Meta/Scenes/L00.unity
@@ -275,6 +275,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: MetaUI
       objectReference: {fileID: 0}
+    - target: {fileID: 9115121989929561526, guid: 33b1efefa5b0c394d98596a8a4ad4215, type: 3}
+      propertyPath: loadingUIDelaySecs
+      value: 0.05
+      objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 8138084430262966543, guid: 33b1efefa5b0c394d98596a8a4ad4215, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 33b1efefa5b0c394d98596a8a4ad4215, type: 3}

--- a/MicroGame-2022-10/Assets/00_Meta/Scripts/LoadingHandler.cs
+++ b/MicroGame-2022-10/Assets/00_Meta/Scripts/LoadingHandler.cs
@@ -14,7 +14,8 @@ public class LoadingHandler : MonoBehaviour
 
     private int sceneIndexToLoad;
 
-    public float loadingUIDelaySecs = 0.3f; // Loading screen is too fast to see so tiny delay.
+    public float loadingUIDelaySecs = .05f; 
+    // Loading screen is too fast to see so tiny delay.
 
     private void Start()
     {
@@ -43,7 +44,18 @@ public class LoadingHandler : MonoBehaviour
     IEnumerator AsyncLoad(int sceneIndex, float delaySecs)
     {
 
-        //Prevent scene activation?
+        // GameManager gets activated as soon as the scene is loaded
+        // Try SceneActivation code
+        // Also can make sure that GameManager activates StartUI after a trigger,
+        // not automatically.
+
+        // REFACTOR
+        // https://docs.unity3d.com/ScriptReference/AsyncOperation-allowSceneActivation.html
+        // When allowSceneActivation is set to false, Unity stops progress at 0.9, and
+        // maintains.isDone at false. When AsyncOperation.allowSceneActivation is set to true,
+        // isDone can complete. While isDone is false, the AsyncOperation queue is stalled. 
+
+        //Prevent scene activation
         //var scene = SceneManager.LoadSceneAsync(sceneIndex);
         //scene.allowSceneActivation = false;
 
@@ -60,11 +72,11 @@ public class LoadingHandler : MonoBehaviour
         {
             yield return new WaitForSecondsRealtime(delaySecs);
             Debug.Log("Waited for: " + delaySecs);
-            if(loadPercent <= operation.progress)
-            { loadPercent = loadPercent + 0.1f; }
+            if (loadPercent <= operation.progress)
+            { loadPercent = loadPercent + .05f; }
             Debug.Log("Operation %:" + loadPercent * 100);
             UpdateSlider(loadPercent);
-            yield return null;
+            yield return null; // waits one frame before proceeding
         }
 
         Debug.Log("AsyncLoad Completed: sceneIndex = " + sceneIndex);
@@ -77,13 +89,14 @@ public class LoadingHandler : MonoBehaviour
             yield return new WaitForSecondsRealtime(delaySecs);
             Debug.Log("Waited for: " + delaySecs);
 
-            loadPercent = loadPercent + 0.1f;
-            // |OR| loadPercent += 0.1f
+            loadPercent = loadPercent + .05f; // |SAME AS| loadPercent += 0.1f
             UpdateSlider(loadPercent);
             yield return null;
         } 
 
         loadPercent = 1f;
+        _metaManager.LoadingComplete = true;
+        Debug.Log(_metaManager.LoadingComplete.ToString());
 
         yield return new WaitForSecondsRealtime(delaySecs);
 
@@ -98,22 +111,8 @@ public class LoadingHandler : MonoBehaviour
         yield return new WaitForSecondsRealtime(delaySecs);
         // Delay to allow SceneActivation to kick in before moving to next action
 
-        _metaManager.UpdateCurrentSceneIndex();
+        _metaManager.TransitionToGameManager();
 
-        var newCurrentSceneIndex = _metaManager.currentSceneIndex;
-        var finalSceneIndex = _metaManager.finalSceneIndex;
-
-        Debug.Log("AsyncLoad: newCurrentSceneIndex = " + newCurrentSceneIndex);
-        Debug.Log("AsyncLoad: finalSceneIndex = " + finalSceneIndex);
-
-        if (newCurrentSceneIndex == finalSceneIndex)
-        {
-            MetaManager.Instance.UpdateMetaState(MetaState.QuitMenu);
-        }
-        else
-        {
-            MetaManager.Instance.UpdateMetaState(MetaState.GameManager);
-        }
     }
 
 }

--- a/MicroGame-2022-10/Assets/00_Meta/Scripts/MetaManager.cs
+++ b/MicroGame-2022-10/Assets/00_Meta/Scripts/MetaManager.cs
@@ -20,6 +20,9 @@ public class MetaManager : MonoBehaviour
     [HideInInspector] public int finalSceneIndex;
     [HideInInspector] public int sceneToLoad = 1;
 
+    [HideInInspector] public bool LoadingComplete; 
+    // Should probably use SceneActivation instead but going to try a quick fix
+
     private void Awake()
     {
         if (Instance == null)
@@ -87,9 +90,24 @@ public class MetaManager : MonoBehaviour
         Debug.Log("HandleSetupApp: MetaState = " + _metaState);
     }
 
+    public void TransitionToMainMenu()
+    {
+        // Check conditions to switch MetaState 
+        // If all conditions are met, change the MetaState
+        // Possibly call this from Update??
+        // This could decouple the calling methods too as they can simply
+        // trigger public switches etc..
+    }
+
     private void HandleMainMenu()
     {
         Debug.Log("HandleMainMenu: MetaState = " + _metaState);
+    }
+
+    public void TransitionToLoadScene()
+    {
+        // Check conditions to switch MetaState 
+        // If all conditions are met, change the MetaState
     }
 
     private void HandleLoadScene()
@@ -100,16 +118,45 @@ public class MetaManager : MonoBehaviour
         Debug.Log("HandleLoadScene: SceneToLoad = " + Instance.sceneToLoad);
     }
 
+    public void TransitionToGameManager()
+    {
+        // Check conditions to switch MetaState 
+        // If all conditions are met, change the MetaState
+        UpdateCurrentSceneIndex();
+        Debug.Log("AsyncLoad: newCurrentSceneIndex = " + Instance.currentSceneIndex);
+        Debug.Log("AsyncLoad: finalSceneIndex = " + finalSceneIndex);
+
+        if (Instance.currentSceneIndex == finalSceneIndex)
+        {
+            MetaManager.Instance.UpdateMetaState(MetaState.QuitMenu);
+        }
+        else
+        {
+            MetaManager.Instance.UpdateMetaState(MetaState.GameManager);
+        }
+    }
+
     private void HandleGameManager()
     {
         Debug.Log("HandleGameManager: MetaState = " + _metaState);
         Debug.Log("MetaManager: Hand over to GameManager");
     }
 
+    public void TransitionToQuitMenu()
+    {
+        // Check conditions to switch MetaState 
+        // If all conditions are met, change the MetaState
+    }
+
     private void HandleQuitMenu()
     {
         Debug.Log("HandleQuitMenu: MetaState = " + _metaState);
+    }
 
+    public void TransitionToQuitApp()
+    {
+        // Check conditions to switch MetaState 
+        // If all conditions are met, change the MetaState
     }
 
     private void HandleQuitApplication()
@@ -118,6 +165,10 @@ public class MetaManager : MonoBehaviour
         Application.Quit();
         Debug.Log("QUIT APPLICATION");
     }
+
+    // REFACTOR ALL BELOW INTO
+    // >> MetaUI?
+    // >> LoadingHandler??
 
     public void LoadMainMenuScene()
     {


### PR DESCRIPTION
        // GameManager gets activated as soon as the scene is loaded
        // Try SceneActivation code
        // Also can make sure that GameManager activates StartUI after a trigger,
        // not automatically.

        // REFACTOR
        // https://docs.unity3d.com/ScriptReference/AsyncOperation-allowSceneActivation.html
        // When allowSceneActivation is set to false, Unity stops progress at 0.9, and
        // maintains.isDone at false. When AsyncOperation.allowSceneActivation is set to true,
        // isDone can complete. While isDone is false, the AsyncOperation queue is stalled.